### PR TITLE
conditional with empty string throws error, expects bool

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     mode: "0750"
     owner: "{{ jellyfin_uid }}"
     group: "{{ jellyfin_gid }}"
-  when: jellyfin_media_bind_path
+  when: jellyfin_media_bind_path != ""
 
 - name: Ensure Jellyfin support files created
   ansible.builtin.template:

--- a/templates/systemd/jellyfin.service.j2
+++ b/templates/systemd/jellyfin.service.j2
@@ -1,4 +1,3 @@
-#jinja2: lstrip_blocks: "True"
 [Unit]
 Description=Jellyfin ({{ jellyfin_identifier }})
 {% for service in jellyfin_systemd_required_services_list %}


### PR DESCRIPTION
I had to change these two lines to make it work. The install.yml was easy, as the error message clearly states that conditional needs to be a bool, while an empty string is of type string. The service template is not that obvious, but I found this change and used it here: https://github.com/borgbase/ansible-role-borgbackup/issues/180