### PR TITLE
Update install.yml condition

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     mode: "0750"
     owner: "{{ jellyfin_uid }}"
     group: "{{ jellyfin_gid }}"
-  when: jellyfin_media_bind_path | bool
+  when: jellyfin_media_bind_path | length > 0
 
 - name: Ensure Jellyfin support files created
   ansible.builtin.template:


### PR DESCRIPTION
fix [DEPRECATION WARNING]: The `bool` filter coerced invalid value '/media' (str) to False. This feature will be removed from ansible-core version 2.23.