### PR TITLE
systemd: make pre-start container cleanup deterministic

### DIFF
--- a/templates/systemd/jellyfin.service.j2
+++ b/templates/systemd/jellyfin.service.j2
@@ -11,7 +11,7 @@ Wants={{ service }}
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ jellyfin_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ jellyfin_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ jellyfin_identifier }}" >&2; exit 1'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ jellyfin_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect --type=container {{ jellyfin_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ jellyfin_identifier }}" >&2; exit 1'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--rm \

--- a/templates/systemd/jellyfin.service.j2
+++ b/templates/systemd/jellyfin.service.j2
@@ -11,8 +11,7 @@ Wants={{ service }}
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ jellyfin_container_stop_grace_time_seconds }} {{ jellyfin_identifier }} 2>/dev/null || true'
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ jellyfin_identifier }} 2>/dev/null || true'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ jellyfin_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ jellyfin_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ jellyfin_identifier }}" >&2; exit 1'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--rm \


### PR DESCRIPTION
## Problem
Container cleanup was hardened with a bounded `rm -f` loop, but the existence check used generic `docker inspect` matching any object type.

## Root Cause
`docker inspect` without `--type=container` can produce false positives when non-container objects share names.

## Fix
- keep deterministic cleanup loop behavior unchanged
- change cleanup verification to `docker inspect --type=container ...` before `docker create`

## Compatibility
No behavior change for healthy cases; this only tightens stale-container detection semantics.

## Validation
- `pre-commit (not configured)`
- `ansible-lint .` passed
