### PR TITLE
Harden pre-create container cleanup to avoid stale-name restart race

### DIFF
--- a/templates/systemd/jellyfin.service.j2
+++ b/templates/systemd/jellyfin.service.j2
@@ -11,8 +11,7 @@ Wants={{ service }}
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ jellyfin_container_stop_grace_time_seconds }} {{ jellyfin_identifier }} 2>/dev/null || true'
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ jellyfin_identifier }} 2>/dev/null || true'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ jellyfin_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect --type=container {{ jellyfin_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ jellyfin_identifier }}" >&2; exit 1'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--rm \


### PR DESCRIPTION
Problem
- During restart, Docker can briefly keep a removed container name reserved, which can make `docker create --name ...` fail with a transient name-conflict error.
- The previous pre-start cleanup was best-effort and left a short race window.

What changed
- This branch was rebased on current `main` and refreshed to align with the cleanup hardening already landed in sibling roles, for example `mother-of-all-self-hosting/ansible-role-adguard-home@97aaa73`.
- `ExecStartPre` now uses the same inline bounded cleanup loop pattern used there.

Behavior
- Pre-start cleanup now uses `docker rm -f`, `docker inspect --type=container`, a bounded 10-attempt retry loop with `sleep 1`, and an explicit failure message if the stale name is still present.

Compatibility
- No intended behavior change beyond deterministic stale-container cleanup before `docker create`.

Validation status
- `ansible-lint .` passes.
- This repo does not currently have a `pre-commit` configuration.
