### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,23 +7,16 @@
   "labels": [
     "dependencies"
   ],
-  "pip_requirements": {
-    "managerFilePatterns": ["(^|/)requirements[^/]*\\.txt$"]
-  },
-  "ansible-galaxy": {
-    "managerFilePatterns": ["(^|/)molecule/default/requirements\\.ya?ml$"]
-  },
-  "pyenv": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchFileNames": [
-        ".pre-commit-config.yaml",
         ".github/workflows/autotag.yml",
         ".github/workflows/molecule.yml",
         ".github/workflows/pre-commit.yml",
-        "mise.toml"
+        ".pre-commit-config.yaml",
+        "mise.toml",
+        "molecule/default/requirements.yml",
+        "molecule/requirements.txt"
       ],
       "enabled": true,
       "automerge": true,
@@ -35,17 +28,6 @@
       "description": "Ignore old date-based versioning scheme (YYYY.MM.DD format)",
       "matchFileNames": ["/defaults/main.yml"],
       "allowedVersions": "!/^20[0-9]{2}\\.[0-9]{1,2}\\.[0-9]{1,2}$/"
-    },
-    {
-      "matchPackageNames": ["ansible", "ansible-core"],
-      "groupName": "ansible",
-      "groupSlug": "ansible"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["lscr.io/linuxserver/jellyfin"],
-      "groupName": "jellyfin docker image",
-      "groupSlug": "jellyfin"
     }
   ],
   "customManagers": [
@@ -60,6 +42,9 @@
     }
   ],
   "pre-commit": {
+    "enabled": true
+  },
+  "pyenv": {
     "enabled": true
   }
 }


### PR DESCRIPTION
Remove redundant definitions from renovate.json: both ansible-galaxy and pip_requirements are discovered automatically, and Autobrr updates are discovered with the matchStrings variable.