### PR TITLE
Remove `ansible-core` from molecule/requirements.txt

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,5 +1,4 @@
 ansible==13.7.0
-ansible-core==2.20.6
 molecule==26.4.0
 molecule-plugins==25.8.12
 docker==7.1.0


### PR DESCRIPTION
`ansible` includes the functionality which `ansible-core` provides, so it is redundant to require both `ansible` and `ansible-core`.

cf. https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html#selecting-an-ansible-package-and-version-to-install

cf. https://github.com/spatterIight/ansible-role-jellyfin/pull/31#issuecomment-4524055608